### PR TITLE
feat: add postgresql support

### DIFF
--- a/.changeset/bumpy-ravens-argue.md
+++ b/.changeset/bumpy-ravens-argue.md
@@ -1,0 +1,10 @@
+---
+"wallet-attached-storage-database": minor
+"wallet-attached-storage-server-nodejs": minor
+"wallet-attached-storage-server-example-hono-node-server": minor
+"wallet-attached-storage-server": minor
+---
+
+Add support for postgresql
+
+This was a bit more involved than expected, because afaict sqlite3 and postgresql do not have any common data type for storing blobs. UUID data types and querything them is also slightly different. Where necessary, Kysely supports introspection such that the wallet-attached-storage-database modules can detect whether the database is backed by sqlite3 or postgresql and adjust behavior accordingly.

--- a/.changeset/cruel-impalas-marry.md
+++ b/.changeset/cruel-impalas-marry.md
@@ -1,0 +1,5 @@
+---
+"wallet-attached-storage-server-nodejs": patch
+---
+
+migrations/1747304776946_add-space-names.ts detects sqlite3 or postgresql and creates blob columns accordingly

--- a/.changeset/fifty-bears-write.md
+++ b/.changeset/fifty-bears-write.md
@@ -1,0 +1,5 @@
+---
+"wallet-attached-storage-server-nodejs": patch
+---
+
+the package.json now has a kysely run script that runs kysely-ctl. Use like `npm run kysely -- migrate:list`

--- a/.changeset/warm-lemons-trade.md
+++ b/.changeset/warm-lemons-trade.md
@@ -1,0 +1,5 @@
+---
+"wallet-attached-storage-database": minor
+---
+
+SpaceRepository detects sqlite vs postgresql and queries blob types in a way that should work for both

--- a/database/src/schema.ts
+++ b/database/src/schema.ts
@@ -1,4 +1,4 @@
-import { Kysely, sql } from "kysely";
+import { Kysely, PostgresIntrospector, sql } from "kysely";
 
 export async function initializeDatabaseSchema<Database>(db: Kysely<Database>) {
   await db.schema
@@ -13,12 +13,16 @@ export async function initializeDatabaseSchema<Database>(db: Kysely<Database>) {
     .ifNotExists()
     .addColumn('uuid', 'uuid', (col) => col.primaryKey())
     .execute()
+
+  const isPostgresql = db.introspection instanceof PostgresIntrospector
+	const blobDataType = isPostgresql ? 'bytea' as const : 'blob' as const
+
   await db.schema
     .createTable('blob')
     .ifNotExists()
     .addColumn('uuid', 'text', (col) => col.primaryKey())
     .addColumn('type', 'text')
-    .addColumn('bytes', 'blob', col => col.notNull())
+    .addColumn('bytes', blobDataType, col => col.notNull())
     .execute()
   await db.schema
     .createTable('resourceRepresentation')

--- a/database/src/space-repository.ts
+++ b/database/src/space-repository.ts
@@ -39,9 +39,6 @@ export default class SpaceRepository implements IRepository<ISpace> {
     }
     try {
       const isPostgresql = this.#database.introspection instanceof PostgresIntrospector
-      console.debug('need to query differently depending on pg vs sqlite', {
-        isPostgresql,
-      })
       if (isPostgresql) {
         return await queryPostgresql(this.#database)
       } else {

--- a/database/src/space-repository.ts
+++ b/database/src/space-repository.ts
@@ -1,4 +1,4 @@
-import { NoResultError, type Insertable, type QueryCreator, type Updateable } from "kysely"
+import { NoResultError, PostgresIntrospector, sql, type Insertable, type QueryCreator, type Updateable } from "kysely"
 import type { Database, DatabaseTables, IRepository, ISpace } from "./types"
 
 export class SpaceNotFound extends Error { }
@@ -13,8 +13,20 @@ export default class SpaceRepository implements IRepository<ISpace> {
    * @throws {SpaceNotFound} if the space cannot be not found
    */
   async getById(id: string) {
-    try {
-      const result = await this.#database.selectFrom('space')
+    async function queryPostgresql(db: Database) {
+      return await db.selectFrom('space')
+        .leftJoin('link', 'link.anchor', sql`space.uuid::text` as any)
+        .select([
+          'space.uuid',
+          'space.name',
+          'space.controller',
+          'link.href as link',
+        ])
+        .where(sql`space.uuid::text`, '=', id)
+        .executeTakeFirstOrThrow()
+    }
+    async function querySqlite(db: Database) {
+      return await db.selectFrom('space')
         .leftJoin('link', 'link.anchor', 'space.uuid')
         .select([
           'space.uuid',
@@ -22,9 +34,19 @@ export default class SpaceRepository implements IRepository<ISpace> {
           'space.controller',
           'link.href as link',
         ])
-        .where('space.uuid', '=', id)
-        .executeTakeFirstOrThrow()
-      return result
+        .where(`space.uuid`, '=', id)
+        .executeTakeFirstOrThrow()      
+    }
+    try {
+      const isPostgresql = this.#database.introspection instanceof PostgresIntrospector
+      console.debug('need to query differently depending on pg vs sqlite', {
+        isPostgresql,
+      })
+      if (isPostgresql) {
+        return await queryPostgresql(this.#database)
+      } else {
+        return await querySqlite(this.#database)
+      }
     } catch (error) {
       if (error instanceof NoResultError) {
         throw new SpaceNotFound(`Space with id ${id} not found`, {

--- a/nodejs/.env.dev
+++ b/nodejs/.env.dev
@@ -1,2 +1,3 @@
 DATABASE_URL=sqlite3:$(pwd)/var/wallet-attached-storage-server.dev.sqlite3
+#DATABASE_URL=postgres://localhost:5432/wallet-attached-storage-server-dev
 PORT=8080

--- a/nodejs/migrations/1747304776946_add-space-names.ts
+++ b/nodejs/migrations/1747304776946_add-space-names.ts
@@ -12,11 +12,10 @@ export async function up(db: Kysely<any>): Promise<void> {
 		.execute()
 
 	const isPostgresql = db.introspection instanceof PostgresIntrospector
-	console.debug('about to create table for blobs. first need to detect undelrying engine to detect blob type', {
-		isPostgresql,
-	})
 	const blobDataType = isPostgresql ? 'bytea' as const : 'blob' as const
-	console.debug('This migration adds a blob column, and there is no common sql datatype for that that works across sqlite and postgresql. We detected', { isPostgresql, blobDataType })
+	console.debug(
+		'This migration adds a blob column, and there is no common sql datatype for that that works across sqlite and postgresql. We detected',
+		{ isPostgresql, blobDataType })
 
 	await db.schema
 		.createTable('blob')

--- a/nodejs/migrations/1747304776946_add-space-names.ts
+++ b/nodejs/migrations/1747304776946_add-space-names.ts
@@ -1,4 +1,4 @@
-import { sql, type Kysely } from 'kysely'
+import { PostgresIntrospector, sql, type Kysely } from 'kysely'
 
 // `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
 export async function up(db: Kysely<any>): Promise<void> {
@@ -10,12 +10,20 @@ export async function up(db: Kysely<any>): Promise<void> {
 		.ifNotExists()
 		.addColumn('uuid', 'uuid', (col) => col.primaryKey())
 		.execute()
+
+	const isPostgresql = db.introspection instanceof PostgresIntrospector
+	console.debug('about to create table for blobs. first need to detect undelrying engine to detect blob type', {
+		isPostgresql,
+	})
+	const blobDataType = isPostgresql ? 'bytea' as const : 'blob' as const
+	console.debug('This migration adds a blob column, and there is no common sql datatype for that that works across sqlite and postgresql. We detected', { isPostgresql, blobDataType })
+
 	await db.schema
 		.createTable('blob')
 		.ifNotExists()
 		.addColumn('uuid', 'text', (col) => col.primaryKey())
 		.addColumn('type', 'text')
-		.addColumn('bytes', 'blob', col => col.notNull())
+		.addColumn('bytes', blobDataType, col => col.notNull())
 		.execute()
 	await db.schema
 		.createTable('resourceRepresentation')
@@ -43,7 +51,17 @@ export async function down(db: Kysely<any>): Promise<void> {
 	// down migration code goes here...
 	// note: down migrations are optional. you can safely delete this function.
 	// For more info, see: https://kysely.dev/docs/migrations
-	await db.schema
-		.dropTable('space')
-		.execute()
+
+
+	for (const tableName of [
+		'spaceNamedResource',
+		'resourceRepresentation',
+		'resource',
+		'blob',
+	]) {
+		console.debug('about to drop', tableName)
+		await db.schema
+			.dropTable(tableName)
+			.execute()
+	}
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "dotenvx run -f .env.dev -- node --watch ./scripts/start.ts",
     "start": "node ./scripts/start.ts",
-    "test": "node --test"
+    "test": "node --test",
+    "kysely": "npx -p kysely-ctl kysely"
   },
   "author": "",
   "license": "MIT",
@@ -14,8 +15,10 @@
   "dependencies": {
     "@hono/node-server": "^1.14.1",
     "better-sqlite3": "^11.10.0",
+    "connection-string": "^4.4.0",
     "kysely-ctl": "^0.12.2",
     "pg": "^8.16.0",
+    "pg-cursor": "^2.15.0",
     "wallet-attached-storage-database": "*",
     "wallet-attached-storage-server": "*"
   },

--- a/nodejs/scripts/start.ts
+++ b/nodejs/scripts/start.ts
@@ -7,6 +7,7 @@ import WAS from 'wallet-attached-storage-server'
 import { initializeDatabaseSchema } from '../../database/src/schema.ts'
 import { parseSqliteDatabaseUrl } from '../../database/src/sqlite3/database-url-sqlite3.ts'
 import * as path from 'node:path'
+import { createKyselyFromDatabaseUrl } from '../src/database-url.ts'
 
 // store data in-memory
 const data = createDatabaseFromEnv({
@@ -51,10 +52,8 @@ function createDatabaseFromEnv(env: {
 }) {
   if (env.DATABASE_URL) {
     console.debug('creating database from DATABASE_URL')
-    const database = createDatabaseFromSqlite3Url(env.DATABASE_URL?.toString())
-    const parsedUrl = parseSqliteDatabaseUrl(env.DATABASE_URL?.toString())
-    const relativeDatabasePath = path.relative(process.cwd(), parsedUrl.pathname)
-    console.debug('database pathname is', relativeDatabasePath)
+    const database = createKyselyFromDatabaseUrl(env.DATABASE_URL?.toString())
+    console.debug('database from DATABASE_URL', database)
     if (database) {
       return database
     }

--- a/nodejs/src/database-url.ts
+++ b/nodejs/src/database-url.ts
@@ -1,5 +1,4 @@
 import { Kysely, PostgresDialect, SqliteDialect } from 'kysely'
-import { fileURLToPath } from 'node:url'
 import { Pool } from 'pg'
 import BetterSqlite3Database from 'better-sqlite3'
 import * as Cursor from 'pg-cursor'


### PR DESCRIPTION
Motivation:
* unblock deploying to DATABASE_URL starting with postgres

Context
* I thought I had already done this in my canary deployment, but it turns out I had only ever deployed it with sqlite3