### PR TITLE
feat: GET /space/:uuid with header `accept: application/x-tar` responds with tar archive

### DIFF
--- a/.changeset/red-animals-hide.md
+++ b/.changeset/red-animals-hide.md
@@ -1,0 +1,8 @@
+---
+"wallet-attached-storage-database": minor
+"wallet-attached-storage-server-nodejs": minor
+"wallet-attached-storage-server": minor
+"wallet-attached-storage-server-example-hono-node-server": minor
+---
+
+GET /space/:uuid with header accept: application/x-tar responds with tar archive

--- a/database/package.json
+++ b/database/package.json
@@ -28,6 +28,10 @@
       "types": "./src/space-repository.ts",
       "import": "./src/space-repository.ts"
     },
+    "./space-tar": {
+      "types": "./src/space-tar.ts",
+      "import": "./src/space-tar.ts"
+    },
     "./sqlite3": {
       "types": "./src/sqlite3/index.ts",
       "import": "./src/sqlite3/index.ts"

--- a/database/package.json
+++ b/database/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
+    "@types/tar-stream": "^3.1.4",
     "kysely": "^0.28.2",
     "kysely-plugin-serialize": "^0.8.2",
     "streaming-iterables": "^8.0.1"

--- a/database/src/space-tar.ts
+++ b/database/src/space-tar.ts
@@ -1,0 +1,67 @@
+import ResourceRepository from './resource-repository.ts'
+import tar from "tar-stream"
+import { Readable, Writable } from 'stream'
+import { blob } from 'stream/consumers'
+
+export async function exportSpaceTar(
+  resources: Pick<ResourceRepository, 'iterateSpaceNamedRepresentations'>,
+  spaceUuid: string
+): Promise<ReadableStream> {
+  const pack = tar.pack()
+
+  // pack should contain a directory named after the space uuid
+  pack.entry({ name: spaceUuid, type: 'directory', })
+
+  const repsInSpace = resources.iterateSpaceNamedRepresentations({
+    space: spaceUuid,
+  })
+
+  // create entry files for each resource in space
+  for await (const rep of repsInSpace) {
+    const searchParams = rep.blob.type ? new URLSearchParams({ ct: rep.blob.type.toLowerCase() }) : undefined
+    const fileName = `${rep.blob.name}${searchParams ? `?${searchParams}` : ''}`
+    const tarEntryName = `${spaceUuid}/${encodeURIComponent(fileName)}`
+    pack.entry(
+      { name: tarEntryName },
+      // @todo dont load whole blob into memory
+      Buffer.from(await rep.blob.arrayBuffer())
+    );
+  }
+  pack.finalize()
+  const t = new TransformStream();
+  (Readable.toWeb(pack) as ReadableStream).pipeThrough(t);
+  return t.readable
+}
+
+export function readFilesFromTar(stream: ReadableStream) {
+  const extract = tar.extract()
+  const files = new ReadableStream<File>({
+    start(controller) {
+      extract.on('entry', (header, stream, next) => {
+        blob(stream).then(async blob => {
+          switch (header.type) {
+            case 'file':
+              const name = header.name
+              const nameParts = name.split('/').map(decodeURIComponent)
+              const entryFileName = nameParts.at(-1)
+              const entryFileNameCt = new URLSearchParams(entryFileName?.replace(/^[^?]+/, '')).get('ct') || undefined
+              controller.enqueue(new File([await blob.arrayBuffer()], header.name, { type: entryFileNameCt }))
+              break;
+            case 'directory':
+              break; // no need to make a File for directories
+            default:
+              console.warn('unsupported tar entry type', header.type, 'for entry', header.name)
+              throw new Error(`Unsupported tar entry type: ${header.type} for entry ${header.name}`);
+          }
+          next()
+        })
+      })
+      extract.on('finish', () => {
+        controller.close()
+      })
+      stream.pipeTo(Writable.toWeb(extract))
+    }
+  })
+
+  return files;
+}

--- a/database/src/test/test-space-export-tar.test.ts
+++ b/database/src/test/test-space-export-tar.test.ts
@@ -1,0 +1,121 @@
+import { describe, test } from 'node:test'
+import assert from "assert"
+import { createDatabaseFromSqlite3Url } from '../sqlite3/database-url-sqlite3.ts'
+import { initializeDatabaseSchema } from "../schema.ts"
+import SpaceRepository from '../space-repository.ts'
+import ResourceRepository from '../resource-repository.ts'
+import type { Database, ISpace } from '../types.ts'
+import { collect } from 'streaming-iterables'
+import tar from "tar-stream"
+import { Readable, Writable } from 'stream'
+import { blob } from 'stream/consumers'
+
+await test(`can export database as tar`, async t => {
+  // setup database
+  let database: Database
+  {
+    database = createDatabaseFromSqlite3Url(`sqlite3::memory:`)
+    await initializeDatabaseSchema(database)
+  }
+  // create a space
+  let createdSpace: ISpace
+  {
+    const spaceToCreate = {
+      name: 'test-space',
+      uuid: crypto.randomUUID(),
+      controller: null,
+      link: null,
+    }
+    await new SpaceRepository(database).create(spaceToCreate);
+    createdSpace = spaceToCreate
+  }
+  // add resources to space
+  const resourcesToAdd = Object.entries({
+    'resource1': new Blob(['resource1 content'], { type: 'text/plain' }),
+  })
+  {
+    for (const [name, representation] of resourcesToAdd) {
+      await new ResourceRepository(database).putSpaceNamedResource({
+        space: createdSpace.uuid,
+        name,
+        representation,
+      })
+    }
+  }
+  // export space as tar
+  let exportedTarStream: ReadableStream
+  {
+    const exported = await exportSpaceAsTar(database, createdSpace.uuid)
+    assert.ok(exported, `result of exportSpaceAsTar must be truthy`)
+    exportedTarStream = exported
+  }
+  // verify exported tar
+  {
+    const files = await collect(readFilesFromTar(exportedTarStream))
+    assert.equal(files.length, resourcesToAdd.length,
+      `expected ${resourcesToAdd.length} files in tar, got ${files.length}`)
+    assert.ok(files.some(f => f.type === `text/plain`),
+      `encoding/decoding preserves media type`)
+  }
+})
+
+async function exportSpaceAsTar(database: Database, spaceUuid: string): Promise<ReadableStream> {
+  const pack = tar.pack()
+
+  // pack should contain a directory named after the space uuid
+  pack.entry({ name: spaceUuid, type: 'directory', })
+
+  const resourceRepo = new ResourceRepository(database)
+  const repsInSpace = resourceRepo.iterateSpaceNamedRepresentations({
+    space: spaceUuid,
+  })
+
+  // create entry files for each resource in space
+  for await (const rep of repsInSpace) {
+    const searchParams = rep.blob.type ? new URLSearchParams({ct:rep.blob.type.toLowerCase()}) : undefined
+    const fileName = `${rep.blob.name}${searchParams ? `?${searchParams}` : ''}`
+    const tarEntryName = `${spaceUuid}/${encodeURIComponent(fileName)}`
+    pack.entry(
+      { name: tarEntryName },
+      // @todo dont load whole blob into memory
+      Buffer.from(await rep.blob.arrayBuffer())
+    );
+  }
+  pack.finalize()
+  const t = new TransformStream();
+  (Readable.toWeb(pack) as ReadableStream).pipeThrough(t);
+  return t.readable
+}
+
+function readFilesFromTar(stream: ReadableStream) {
+  const extract = tar.extract()
+  const files = new ReadableStream<File>({
+    start(controller) {
+      extract.on('entry', (header, stream, next) => {
+        blob(stream).then(async blob => {
+          switch (header.type) {
+            case 'file':
+              const name = header.name
+              const nameParts = name.split('/').map(decodeURIComponent)
+              const entryFileName = nameParts.at(-1)
+              const entryFileNameCt = new URLSearchParams(entryFileName?.replace(/^[^?]+/,'')).get('ct') || undefined
+              controller.enqueue(new File([await blob.arrayBuffer()], header.name, { type: entryFileNameCt }))
+              break;
+            case 'directory':
+              break; // no need to make a File for directories
+            default:
+              console.warn('unsupported tar entry type', header.type, 'for entry', header.name)
+              throw new Error(`Unsupported tar entry type: ${header.type} for entry ${header.name}`);
+          }
+          next()
+        })
+      })
+      extract.on('finish', () => {
+        controller.close()
+      })
+      stream.pipeTo(Writable.toWeb(extract))
+    }
+  })
+
+  return files;
+}

--- a/database/src/test/test-space-export-tar.test.ts
+++ b/database/src/test/test-space-export-tar.test.ts
@@ -6,9 +6,7 @@ import SpaceRepository from '../space-repository.ts'
 import ResourceRepository from '../resource-repository.ts'
 import type { Database, ISpace } from '../types.ts'
 import { collect } from 'streaming-iterables'
-import tar from "tar-stream"
-import { Readable, Writable } from 'stream'
-import { blob } from 'stream/consumers'
+import { exportSpaceTar, readFilesFromTar } from '../space-tar.ts'
 
 await test(`can export database as tar`, async t => {
   // setup database
@@ -45,7 +43,7 @@ await test(`can export database as tar`, async t => {
   // export space as tar
   let exportedTarStream: ReadableStream
   {
-    const exported = await exportSpaceAsTar(database, createdSpace.uuid)
+    const exported = await exportSpaceTar(new ResourceRepository(database), createdSpace.uuid)
     assert.ok(exported, `result of exportSpaceAsTar must be truthy`)
     exportedTarStream = exported
   }
@@ -58,64 +56,3 @@ await test(`can export database as tar`, async t => {
       `encoding/decoding preserves media type`)
   }
 })
-
-async function exportSpaceAsTar(database: Database, spaceUuid: string): Promise<ReadableStream> {
-  const pack = tar.pack()
-
-  // pack should contain a directory named after the space uuid
-  pack.entry({ name: spaceUuid, type: 'directory', })
-
-  const resourceRepo = new ResourceRepository(database)
-  const repsInSpace = resourceRepo.iterateSpaceNamedRepresentations({
-    space: spaceUuid,
-  })
-
-  // create entry files for each resource in space
-  for await (const rep of repsInSpace) {
-    const searchParams = rep.blob.type ? new URLSearchParams({ct:rep.blob.type.toLowerCase()}) : undefined
-    const fileName = `${rep.blob.name}${searchParams ? `?${searchParams}` : ''}`
-    const tarEntryName = `${spaceUuid}/${encodeURIComponent(fileName)}`
-    pack.entry(
-      { name: tarEntryName },
-      // @todo dont load whole blob into memory
-      Buffer.from(await rep.blob.arrayBuffer())
-    );
-  }
-  pack.finalize()
-  const t = new TransformStream();
-  (Readable.toWeb(pack) as ReadableStream).pipeThrough(t);
-  return t.readable
-}
-
-function readFilesFromTar(stream: ReadableStream) {
-  const extract = tar.extract()
-  const files = new ReadableStream<File>({
-    start(controller) {
-      extract.on('entry', (header, stream, next) => {
-        blob(stream).then(async blob => {
-          switch (header.type) {
-            case 'file':
-              const name = header.name
-              const nameParts = name.split('/').map(decodeURIComponent)
-              const entryFileName = nameParts.at(-1)
-              const entryFileNameCt = new URLSearchParams(entryFileName?.replace(/^[^?]+/,'')).get('ct') || undefined
-              controller.enqueue(new File([await blob.arrayBuffer()], header.name, { type: entryFileNameCt }))
-              break;
-            case 'directory':
-              break; // no need to make a File for directories
-            default:
-              console.warn('unsupported tar entry type', header.type, 'for entry', header.name)
-              throw new Error(`Unsupported tar entry type: ${header.type} for entry ${header.name}`);
-          }
-          next()
-        })
-      })
-      extract.on('finish', () => {
-        controller.close()
-      })
-      stream.pipeTo(Writable.toWeb(extract))
-    }
-  })
-
-  return files;
-}

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "main": "index.js",
   "scripts": {
-    "dev": "dotenvx run -f .env.dev -- node --watch ./scripts/start.ts",
+    "dev": "dotenvx run -f .env.dev -- node --no-warnings --watch ./scripts/start.ts",
     "start": "node ./scripts/start.ts",
     "test": "node --test",
     "kysely": "npx -p kysely-ctl kysely"
@@ -14,6 +14,7 @@
   "description": "",
   "dependencies": {
     "@hono/node-server": "^1.14.1",
+    "@types/pg-cursor": "^2.7.2",
     "better-sqlite3": "^11.10.0",
     "connection-string": "^4.4.0",
     "kysely-ctl": "^0.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,6 +555,12 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
       "license": "MIT"
     },
+    "node_modules/@types/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@types/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-JkXTOdKs5MF086b/pt8C3+yVp3iDUwG635L7oCH6HvJvvr6lSUU5oe/gLXnPEfYRROHjJIPgCV6cuAg8gGkntQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.15.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
@@ -562,6 +568,27 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.4.tgz",
+      "integrity": "sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-cursor": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/pg-cursor/-/pg-cursor-2.7.2.tgz",
+      "integrity": "sha512-m3xT8bVFCvx98LuzbvXyuCdT/Hjdd/v8ml4jL4K1QF70Y8clOfCFdgoaEB1FWdcSwcpoFYZTJQaMD9/GQ27efQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/tar-stream": {
@@ -1539,6 +1566,15 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.75.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
@@ -2364,6 +2400,7 @@
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
+        "@types/pg-cursor": "^2.7.2",
         "better-sqlite3": "^11.10.0",
         "connection-string": "^4.4.0",
         "kysely-ctl": "^0.12.2",
@@ -2386,10 +2423,12 @@
       "dependencies": {
         "@did.coop/did-key-ed25519": "github:did-coop/did-key-ed25519",
         "@hono/zod-validator": "^0.5.0",
+        "@types/negotiator": "^0.6.3",
         "authorization-signature": "github:gobengo/authorization-signature",
         "canonicalize": "^2.1.0",
         "hono": "^4.7.9",
         "hono-zcap": "^1.0.0",
+        "negotiator": "^1.0.0",
         "streaming-iterables": "^8.0.1",
         "uuid": "github:gobengo/uuid",
         "whatwg-mimetype": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -600,6 +600,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@wallet.storage/fetch-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@wallet.storage/fetch-client/-/fetch-client-1.2.0.tgz",
+      "integrity": "sha512-i2UFHCPB7ybJQyPQsmKHcGKIz2pe97WRb5DlD0Ot5bSMbvWtdBJuizd6Y12/adBWCpB73E2XhTCbUsQf/M4XKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "authorization-signature": "^1.0.3",
+        "zod": "^3.24.1"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2424,6 +2434,7 @@
         "@did.coop/did-key-ed25519": "github:did-coop/did-key-ed25519",
         "@hono/zod-validator": "^0.5.0",
         "@types/negotiator": "^0.6.3",
+        "@wallet.storage/fetch-client": "^1.2.0",
         "authorization-signature": "github:gobengo/authorization-signature",
         "canonicalize": "^2.1.0",
         "hono": "^4.7.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,10 @@
     },
     "database": {
       "name": "wallet-attached-storage-database",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "@types/tar-stream": "^3.1.4",
         "kysely": "^0.28.2",
         "kysely-plugin-serialize": "^0.8.2",
         "streaming-iterables": "^8.0.1"
@@ -30,7 +31,7 @@
     },
     "examples/hono-node-server": {
       "name": "wallet-attached-storage-server-example-hono-node-server",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
@@ -553,6 +554,24 @@
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-3.1.4.tgz",
+      "integrity": "sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2235,6 +2254,12 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2335,7 +2360,7 @@
     },
     "nodejs": {
       "name": "wallet-attached-storage-server-nodejs",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
@@ -2356,7 +2381,7 @@
     },
     "server": {
       "name": "wallet-attached-storage-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@did.coop/did-key-ed25519": "github:did-coop/did-key-ed25519",

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "@did.coop/did-key-ed25519": "github:did-coop/did-key-ed25519",
     "@hono/zod-validator": "^0.5.0",
     "@types/negotiator": "^0.6.3",
+    "@wallet.storage/fetch-client": "^1.2.0",
     "authorization-signature": "github:gobengo/authorization-signature",
     "canonicalize": "^2.1.0",
     "hono": "^4.7.9",

--- a/server/package.json
+++ b/server/package.json
@@ -14,10 +14,12 @@
   "dependencies": {
     "@did.coop/did-key-ed25519": "github:did-coop/did-key-ed25519",
     "@hono/zod-validator": "^0.5.0",
+    "@types/negotiator": "^0.6.3",
     "authorization-signature": "github:gobengo/authorization-signature",
     "canonicalize": "^2.1.0",
     "hono": "^4.7.9",
     "hono-zcap": "^1.0.0",
+    "negotiator": "^1.0.0",
     "streaming-iterables": "^8.0.1",
     "uuid": "github:gobengo/uuid",
     "whatwg-mimetype": "^4.0.0",

--- a/server/src/lib/http.ts
+++ b/server/src/lib/http.ts
@@ -1,0 +1,17 @@
+import Negotiator from "negotiator"
+
+// convert DOM-style Headers to Node.js style headers
+export function toNodeHeaders(headers: Headers) {
+  const nodeHeaders: Record<string, string[] | string> = {}
+  for (const [key, value] of headers.entries()) {
+    const normalizedKey = key.toLowerCase()
+    const prev = nodeHeaders[normalizedKey]
+    nodeHeaders[normalizedKey] = Array.isArray(prev) ? [...prev, value] : prev ? [prev, value] : value
+  }
+  return nodeHeaders
+}
+
+export function negotiate(headers: Headers, supportedMediaTypes: string[]) {
+  const negotiator = new Negotiator({ headers: toNodeHeaders(headers) })
+  return negotiator.mediaType(supportedMediaTypes)
+}

--- a/server/src/routes/space.$uuid.ts
+++ b/server/src/routes/space.$uuid.ts
@@ -2,25 +2,9 @@ import type { Context, Next } from "hono"
 import type SpaceRepository from "../../../database/src/space-repository.ts"
 import { HTTPException } from 'hono/http-exception'
 import { PutSpaceRequestBodyShape } from "../shapes/PutSpaceRequestBody.ts"
-import Negotiator from "negotiator"
 import { exportSpaceTar } from "wallet-attached-storage-database/space-tar"
 import ResourceRepository from "wallet-attached-storage-database/resource-repository"
-import { stream } from 'hono/streaming'
-
-function toNodeHeaders(headers: Headers) {
-  const nodeHeaders: Record<string, string[] | string> = {}
-  for (const [key, value] of headers.entries()) {
-    const normalizedKey = key.toLowerCase()
-    const prev = nodeHeaders[normalizedKey]
-    nodeHeaders[normalizedKey] = Array.isArray(prev) ? [...prev, value] : prev ? [prev, value] : value
-  }
-  return nodeHeaders
-}
-
-function negotiate(headers: Headers, supportedMediaTypes: string[]) {
-  const negotiator = new Negotiator({ headers: toNodeHeaders(headers) })
-  return negotiator.mediaType(supportedMediaTypes)
-}
+import { negotiate } from "../lib/http.ts"
 
 /**
  * build a route to get a space by uuid from a space repository

--- a/server/src/routes/space.$uuid.ts
+++ b/server/src/routes/space.$uuid.ts
@@ -1,31 +1,60 @@
 import type { Context, Next } from "hono"
 import type SpaceRepository from "../../../database/src/space-repository.ts"
-import { HttpSignatureAuthorization } from "authorization-signature"
-import { getVerifierForKeyId } from "@did.coop/did-key-ed25519/verifier"
 import { HTTPException } from 'hono/http-exception'
-import { getControllerOfDidKeyVerificationMethod } from "@did.coop/did-key-ed25519/did-key"
 import { PutSpaceRequestBodyShape } from "../shapes/PutSpaceRequestBody.ts"
-import type { PutSpaceRequestBody } from "../shapes/PutSpaceRequestBody.ts"
-import { treeifyError, z } from "zod/v4";
+import Negotiator from "negotiator"
+import { exportSpaceTar } from "wallet-attached-storage-database/space-tar"
+import ResourceRepository from "wallet-attached-storage-database/resource-repository"
+import { stream } from 'hono/streaming'
+
+function toNodeHeaders(headers: Headers) {
+  const nodeHeaders: Record<string, string[] | string> = {}
+  for (const [key, value] of headers.entries()) {
+    const normalizedKey = key.toLowerCase()
+    const prev = nodeHeaders[normalizedKey]
+    nodeHeaders[normalizedKey] = Array.isArray(prev) ? [...prev, value] : prev ? [prev, value] : value
+  }
+  return nodeHeaders
+}
+
+function negotiate(headers: Headers, supportedMediaTypes: string[]) {
+  const negotiator = new Negotiator({ headers: toNodeHeaders(headers) })
+  return negotiator.mediaType(supportedMediaTypes)
+}
 
 /**
  * build a route to get a space by uuid from a space repository
  * @param spaces - the space repository to query
  * @returns - hono handler
  */
-export function GET(
+export function GET(o: {
   spaces: Pick<SpaceRepository, 'getById'>,
-) {
+  resources: ResourceRepository,
+}) {
   // hono request handler
-  // use like
-  //   (new Hono).get('/spaces/:uuid', GET(spaces))
+  // @example (new Hono).get('/spaces/:uuid', GET(spaces))
   return async (c: Context<any, '/:uuid'>) => {
     const uuid = c.req.param('uuid')
-    const space = await spaces.getById(uuid)
+    const space = await o.spaces.getById(uuid)
     if (!space) {
       // space does not exist
       // return 401. same as if space does exist but request includes insufficient authorization
       return c.newResponse(null, 401)
+    }
+    const contentType = negotiate(c.req.raw.headers, ['application/json', 'application/x-tar'])
+    switch (contentType) {
+      case `application/x-tar`: {
+        // export space as tar
+        const spaceTar = await exportSpaceTar(o.resources, uuid)
+        return new Response(spaceTar, {
+          headers: {
+            'Content-Type': 'application/x-tar',
+            'Content-Disposition': `attachment; filename="space.${uuid}.tar"`,
+          },
+        })
+        break;
+      }
+      // fall through for default which is application/json
     }
     return c.json(space, 200)
   }
@@ -77,39 +106,4 @@ export function DELETE(
     await spaces.deleteById(uuid)
     return c.newResponse(null, 204)
   }
-}
-
-class AuthorizationMissing extends Error { }
-class NotAuthorized extends Error { }
-
-async function assertRequestAuthorizedBy(
-  request: Request,
-  controller: string,
-) {
-  if (!request.headers.get('authorization')) {
-    throw new AuthorizationMissing(`Authorization is required but missing.`)
-  }
-
-  let authenticatedRequestKeyId: string
-  try {
-    const verified = await HttpSignatureAuthorization.verified(request, {
-      async getVerifier(keyId) {
-        const { verifier } = await getVerifierForKeyId(keyId)
-        return verifier
-      },
-    })
-    authenticatedRequestKeyId = verified.keyId
-  } catch (error) {
-    throw new Error(`Failed to verify HTTP Signature`, {
-      cause: error,
-    })
-  }
-
-  const authenticatedRequestDid = getControllerOfDidKeyVerificationMethod(authenticatedRequestKeyId as `did:key:${string}#${string}`)
-  if (authenticatedRequestDid === controller) {
-    // the request is authorized because it is signed by the controller
-    return
-  }
-
-  throw new NotAuthorized(`Insufficient authorization provided to respond to this request.`)
 }

--- a/server/src/scripts/check-server-can-export-space-tar.ts
+++ b/server/src/scripts/check-server-can-export-space-tar.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env node --no-warnings
+
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { StorageClient } from "@wallet.storage/fetch-client"
+import { Ed25519Signer } from "@did.coop/did-key-ed25519";
+import { createHttpSignatureAuthorization } from "authorization-signature";
+import { collect } from "streaming-iterables";
+import { readFilesFromTar } from "wallet-attached-storage-database/space-tar"
+
+// when this script is executed directly, run the main function.
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(...process.argv).catch(error => {
+    console.error(error);
+    process.exit(1)
+  })
+}
+
+async function main(...argv: string[]) {
+  const options = {
+    space: { type: 'string' },
+    storage: { type: 'string', }
+  } as const;
+  const args = parseArgs({
+    args: argv.slice(2),
+    options,
+  })
+
+  // parse --url arg to URL
+  if (!args.values.storage) throw new Error("Missing required argument: --storage");
+  let storageUrl: URL;
+  try {
+    storageUrl = new URL(args.values.storage);
+  } catch (error) {
+    throw new Error(`Invalid storage URL: ${args.values.storage}`, { cause: error });
+  }
+
+  // let r1 be a resource of type text/plain and content 'r1'
+  const r1Representation = new Blob(['r1'], { type: 'text/plain' });
+
+  // create a key to use for authn
+  const key = await Ed25519Signer.generate()
+
+  // create storage client for space.
+  const storage = new StorageClient(storageUrl)
+
+  // create a space.
+  const spaceId: `urn:uuid:${string}` = args.values.space?.startsWith('urn:uuid:')
+    ? args.values.space as `urn:uuid:${string}`
+    : `urn:uuid:${args.values.space || crypto.randomUUID()}` as const;
+  const space = storage.space(spaceId);
+
+  // add the space to storage
+  const spaceToAdd = {
+    controller: key.controller,
+  }
+  const responseToPutSpace = await space.put(new Blob([JSON.stringify(spaceToAdd)], { type: 'application/json' }));
+  console.debug('responseToPutSpace', { status: responseToPutSpace.status })
+
+  // create a resource in the space.
+  const r1 = space.resource('r1')
+  const responseToPutR1 = await r1.put(r1Representation, { signer: key })
+  console.debug('responseToPutR1', { status: responseToPutR1.status })
+  if (!responseToPutR1.ok) throw new Error(`Failed to put r1 (${responseToPutR1.status}}`, { cause: { response: responseToPutR1 } })
+
+  // export the space to tar
+  const spaceURL = new URL(space.path, storageUrl)
+  const requestToGetSpaceTarHeaders = {
+      accept: `application/x-tar`,
+  }
+  const requestToGetSpaceTar = new Request(spaceURL, {
+    headers: {
+      ...requestToGetSpaceTarHeaders,
+      authorization: await createHttpSignatureAuthorization({
+        signer: key,
+        url: spaceURL,
+        method: 'GET',
+        headers: requestToGetSpaceTarHeaders,
+        includeHeaders: [
+          'accept',
+          '(created)',
+          '(expires)',
+          '(key-id)',
+          '(request-target)',
+        ],
+        created: new Date,
+        expires: new Date(Date.now() + 30 * 1000),
+      }),
+    }
+  })
+  const responseToGetSpaceTar = await fetch(requestToGetSpaceTar)
+  console.debug('responseToGetSpaceTar', { status: responseToGetSpaceTar.status })
+
+  // extract tar
+  const filesFromTar = await collect(readFilesFromTar(responseToGetSpaceTar.body as ReadableStream));
+  console.debug('filesFromTar', filesFromTar)
+
+  // ensure exported tar contains the resource
+  let fileIncludesR1 = false;
+  for (const file of filesFromTar) {
+    const fileBasenameEncoded = file.name.split('/').pop();
+    const fileBasenameWithQuery = fileBasenameEncoded && decodeURIComponent(fileBasenameEncoded)
+    const fileBasename = fileBasenameWithQuery?.split('?')[0]
+    if (fileBasename === 'r1') {
+      fileIncludesR1 = true;
+      const fileContent = await file.text();
+      if (fileContent !== await r1Representation.text()) {
+        throw new Error(`File r1 content does not match expected content`);
+      }
+    }
+  }
+  if ( ! fileIncludesR1) throw new Error(`Exported tar does not contain file r1`);
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,6 +13,7 @@ import { SpaceResourceHono } from "./routes/space.$uuid.$name.ts"
 import { HTTPException } from "hono/http-exception"
 import { treeifyError, ZodError } from "zod/v4"
 import { env } from 'hono/adapter'
+import ResourceRepository from "wallet-attached-storage-database/resource-repository"
 
 
 interface IServerOptions {
@@ -32,6 +33,7 @@ export class ServerHono extends Hono {
   }
   static configureRoutes(hono: Hono, data: Database, options?: IServerOptions) {
     const spaces = new SpaceRepository(data)
+    const resources = new ResourceRepository(data)
     // add error handlerno to format ZodErrors
     hono.onError(async (error, c) => {
 
@@ -78,11 +80,11 @@ export class ServerHono extends Hono {
 
     // GET /space/:uuid
     hono.get('/space/:uuid',
-      authorizeWithSpace({
-        data,
-        space: async (c) => spaces.getById(c.req.param('uuid'))
-      }),
-      getSpaceByUuid(spaces))
+      // authorizeWithSpace({
+      //   data,
+      //   space: async (c) => spaces.getById(c.req.param('uuid'))
+      // }),
+      getSpaceByUuid({spaces,resources}))
 
     // PUT /space/:uuid
     hono.put('/space/:uuid',

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -80,10 +80,10 @@ export class ServerHono extends Hono {
 
     // GET /space/:uuid
     hono.get('/space/:uuid',
-      // authorizeWithSpace({
-      //   data,
-      //   space: async (c) => spaces.getById(c.req.param('uuid'))
-      // }),
+      authorizeWithSpace({
+        data,
+        space: async (c) => spaces.getById(c.req.param('uuid'))
+      }),
       getSpaceByUuid({spaces,resources}))
 
     // PUT /space/:uuid

--- a/server/src/test/server-export-space-tar.test.ts
+++ b/server/src/test/server-export-space-tar.test.ts
@@ -1,0 +1,91 @@
+import { describe, test } from 'node:test'
+import { Server } from '../server.ts'
+import { createDatabaseFromSqlite3Url } from 'wallet-attached-storage-database/sqlite3'
+import * as wasdb from 'wallet-attached-storage-database'
+import assert from 'assert'
+import { Ed25519Signer } from '@did.coop/did-key-ed25519'
+import { createHttpSignatureAuthorization } from 'authorization-signature'
+import MIMEType from "whatwg-mimetype"
+import { createRequestForCapabilityInvocation } from 'dzcap/zcap-invocation-request'
+import { delegate } from 'dzcap/delegation'
+import type { ISpace } from 'wallet-attached-storage-database/types'
+import ResourceRepository from 'wallet-attached-storage-database/resource-repository'
+import { collect } from 'streaming-iterables'
+import { readFilesFromTar } from 'wallet-attached-storage-database/space-tar'
+
+// create a database suitable for constructing a testable Server(database)
+async function createTestDatabase() {
+  const database = createDatabaseFromSqlite3Url('sqlite::memory:')
+  await wasdb.initializeDatabaseSchema(database)
+  return database
+}
+
+await test('server exporting space to tar', async t => {
+  const database = await createTestDatabase()
+  const server = new Server(database)
+  const spaceUuid = crypto.randomUUID()
+  // add a space
+  {
+    await new wasdb.SpaceRepository(database).put({
+      uuid: spaceUuid,
+    })
+  }
+  // add a resource
+  {
+    const example1 = new File(['example1 content'], 'example1', { type: 'text/plain' })
+    const resources = new ResourceRepository(database)
+    await resources.putSpaceNamedResource({
+      space: spaceUuid,
+      name: example1.name,
+      representation: example1,
+    })
+  }
+  // export as tar
+  {
+    const requestToGetSpaceTar = new Request(`https://example.example/space/${spaceUuid}`, {
+      headers: {
+        accept: `application/x-tar`,
+      }
+    })
+    const responseToGetSpaceTar = await server.fetch(requestToGetSpaceTar)
+    console.debug('responseToGetSpaceTar', responseToGetSpaceTar)
+    if (!responseToGetSpaceTar.ok) {
+      console.warn(`unexpected not ok response from server when exporting space as tar`, responseToGetSpaceTar)
+      throw new Error(`Unable to export space as tar`, { cause: { responseToGetSpaceTar } })
+    }
+    assert.equal(responseToGetSpaceTar.status, 200, `expected response status to be 200`)
+
+    // ensure the response content-type is application/x-tar
+    assert.equal(responseToGetSpaceTar.headers.get('content-type'), 'application/x-tar',
+      `expected response content-type to be tar`)
+
+    const exportedTar = await responseToGetSpaceTar.blob()
+    const files = await collect(readFilesFromTar(exportedTar.stream()))
+    console.debug(`exported tar files`, files)
+    assert.equal(files.length, 1, `expected to get files from tar`)
+  }
+})
+
+async function addSpaceToServer(server: Server, spaceIn?: ISpace | undefined) {
+  const spaceUuid = spaceIn?.uuid || crypto.randomUUID()
+  const key = await Ed25519Signer.generate()
+  const space = spaceIn ? spaceIn : {
+    controller: key.controller,
+    uuid: spaceUuid
+  }
+  const spacePath = `/space/${spaceUuid}`
+  const spaceURL = new URL(spacePath, `https://example.example`)
+  const requestToAddSpace = new Request(spaceURL, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(space, undefined)
+  })
+  const responseToAddSpace = await server.fetch(requestToAddSpace)
+  if (!responseToAddSpace.ok) {
+    console.warn(`unexpected not ok response from server when adding space`, responseToAddSpace)
+    throw new Error(`Unable to add space`, { cause: { responseToAddSpace } })
+  }
+  return { space }
+}

--- a/server/src/test/server-export-space-tar.test.ts
+++ b/server/src/test/server-export-space-tar.test.ts
@@ -48,7 +48,6 @@ await test('server exporting space to tar', async t => {
       }
     })
     const responseToGetSpaceTar = await server.fetch(requestToGetSpaceTar)
-    console.debug('responseToGetSpaceTar', responseToGetSpaceTar)
     if (!responseToGetSpaceTar.ok) {
       console.warn(`unexpected not ok response from server when exporting space as tar`, responseToGetSpaceTar)
       throw new Error(`Unable to export space as tar`, { cause: { responseToGetSpaceTar } })
@@ -61,7 +60,6 @@ await test('server exporting space to tar', async t => {
 
     const exportedTar = await responseToGetSpaceTar.blob()
     const files = await collect(readFilesFromTar(exportedTar.stream()))
-    console.debug(`exported tar files`, files)
     assert.equal(files.length, 1, `expected to get files from tar`)
   }
 })


### PR DESCRIPTION
Motivation:
* implement something that works for 'Export Contents of Wallet Storage' user story on https://wallet.storage/
* implicitly suggest to spec process that this is something we might want to recommend